### PR TITLE
SharedDataTestCase

### DIFF
--- a/anyblok/bloks/model_authz/tests/__init__.py
+++ b/anyblok/bloks/model_authz/tests/__init__.py
@@ -1,0 +1,7 @@
+# This file is a part of the AnyBlok project
+#
+#    Copyright (C) 2018 Georges Racinet <gracinet@anybox.fr>
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file,You can
+# obtain one at http://mozilla.org/MPL/2.0/.

--- a/anyblok/bloks/model_authz/tests/test_shared_data_testcase.py
+++ b/anyblok/bloks/model_authz/tests/test_shared_data_testcase.py
@@ -1,0 +1,186 @@
+# This file is a part of the AnyBlok project
+#
+#    Copyright (C) 2015 Georges Racinet <gracinet@anybox.fr>
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file,You can
+# obtain one at http://mozilla.org/MPL/2.0/.
+
+"""This module's main purpose is to test the tests base classes.
+
+Testing mod_authz itself is not the primary objective, we simply needed a
+Blok and a very simple, non structural model, to exert the tests base
+classes.
+"""
+import unittest
+from anyblok.tests.testcase import SharedDataTestCase
+from anyblok.tests.testcase import BlokTestCase
+
+
+class Helper:
+    """A mixin to be added to testing test classes.
+
+    The purpose of this mixin is to provide a high-level API to create
+    and test registry and database conditions.
+    """
+
+    @classmethod
+    def break_registry(cls):
+        """Voluntarily break the database connection."""
+        Blok = cls.registry.System.Blok
+        # this is a Programming Error (type is wrong)
+        # without proper rollbacking, any test running after that
+        # would be in error, too.
+        Blok.query().filter(Blok.name == 2).all()
+
+    def assert_pristine_registry(self):
+        """Assert that the registry works and has no leftover test data."""
+        # always True, but needs the DB and registry to work
+        self.assertEqual(
+            self.registry.System.Blok.query().filter_by(
+                name='no-such-blok').count(),
+            0)
+        # actual rollback of shared test data
+        Grant = self.registry.Authorization.ModelPermissionGrant
+        self.assertEqual(Grant.query().count(), 0)
+
+
+class TestSharedDataTestCaseException(unittest.TestCase):
+    """Test class with an exception in setUpSharedData.
+
+    We want to ensure that the test is indeed an error, but the
+    database connection is not broken.
+
+    In these tests, we use :class:`unittest.TestSuite` to perform the
+    various stages of setup (and avoid relying too much on unittest
+    internal API). Also :class:`unittest.TestSuite` promises to run the
+    tests in the order they were added (we double check that anyway).
+    """
+
+    def test_without_error(self):
+        """Test normal rollbacks of individual test cases and class."""
+
+        run_order = []
+
+        class SharedData(SharedDataTestCase, Helper):
+
+            @classmethod
+            def setUpSharedData(cls):
+                cls.Grant = cls.registry.Authorization.ModelPermissionGrant
+                cls.grant = cls.Grant.insert(model='abc',
+                                             principal='me',
+                                             permission='read')
+
+            def test_normal(self):
+                """Changes the data, and should be rollbacked in tearDown."""
+                run_order.append('normal')
+                self.assertEqual(self.grant.principal, 'me')
+                self.grant.principal = 'changed'
+                self.registry.flush()
+                self.assertEqual(
+                    self.Grant.query().filter_by(principal='changed').count(),
+                    1)
+
+            def test_rollbacked(self):
+                """Previous test has been correctly rollbacked."""
+                run_order.append('rollbacked')
+                self.assertEqual(self.grant.principal, 'me')
+                self.assertEqual(
+                    self.Grant.query().filter_by(principal='me').count(),
+                    1)
+
+        class AfterSharedData(BlokTestCase, Helper):
+
+            def test_class_rollbacked(self):
+                run_order.append('class_rollbacked')
+                self.assert_pristine_registry()
+
+        result = unittest.TestResult()
+
+        suite = unittest.TestSuite()
+        suite.addTest(SharedData('test_normal'))
+        suite.addTest(SharedData('test_rollbacked'))
+        suite.addTest(AfterSharedData('test_class_rollbacked'))
+        suite.run(result)
+
+        self.assertEqual(run_order,
+                         ['normal', 'rollbacked', 'class_rollbacked'])
+        self.assertEqual(result.testsRun, 3)
+        self.assertFalse(result.failures)
+        self.assertFalse(result.errors)
+
+    def test_setup_error(self):
+        """Test rollback of test case and class with error in setUp"""
+
+        run_order = []
+
+        class SharedData(SharedDataTestCase, Helper):
+
+            @classmethod
+            def setUpSharedData(cls):
+                cls.Grant = cls.registry.Authorization.ModelPermissionGrant
+                cls.grant = cls.Grant.insert(model='abc',
+                                             principal='me',
+                                             permission='read')
+
+            def setUp(self):
+                run_order.append('error')
+                super(SharedData, self).setUp()
+                self.break_registry()
+
+            def test_error(self):
+                """Won't even be executed (error is in setUp)"""
+
+        class AfterSharedData(BlokTestCase, Helper):
+
+            def test_class_rollbacked(self):
+                run_order.append('class_rollbacked')
+                self.assert_pristine_registry()
+
+        result = unittest.TestResult()
+
+        suite = unittest.TestSuite()
+        suite.addTest(SharedData('test_error'))
+        suite.addTest(AfterSharedData('test_class_rollbacked'))
+        suite.run(result)
+
+        self.assertEqual(run_order, ['error', 'class_rollbacked'])
+        self.assertEqual(result.testsRun, 2)
+        self.assertEqual(len(result.errors), 1)
+        self.assertFalse(result.failures)
+
+    def test_setup_shared_data_error(self):
+        """Test recovery of database errors in setUpSharedData"""
+
+        run_order = []
+
+        class BadTest(SharedDataTestCase):
+
+            @classmethod
+            def setUpSharedData(cls):
+                run_order.append('test_error')
+                cls.break_registry()
+
+            def test_error(cls):
+                """Won't even be executed (is after error in setUpClass)"""
+
+        class GoodTest(BlokTestCase, Helper):
+
+            def test_ok(self):
+                """Test that registry and db connection work normally."""
+                run_order.append('test_ok')
+                self.assert_pristine_registry()
+
+        result = unittest.TestResult()
+
+        suite = unittest.TestSuite()
+        suite.addTest(BadTest('test_error'))
+        suite.addTest(GoodTest('test_ok'))
+        suite.run(result)
+
+        self.assertEqual(run_order, ['test_error', 'test_ok'])
+        # only test_ok could actually be run
+        self.assertEqual(result.testsRun, 1)
+        # but it succeeded
+        self.assertEqual(len(result.errors), 1)
+        self.assertFalse(result.failures)

--- a/doc/CHANGES.rst
+++ b/doc/CHANGES.rst
@@ -54,6 +54,8 @@ CHANGELOG
   ``pre_migration()``, ``post_migration()`` and ``update()`` the
   ``latest_version`` parameter is now instance
   of ``pkg_resources`` ``Version`` class, or ``None``
+* new tests base class: SharedDataTestCase, allowing to share costly
+  fixtures among tests of the same class
 * scripts: removed useless and too magic ``need_blok``
 * fixed Travis configuration for python 3.7
 * plugins sytem optimization: removed stub implementations for all

--- a/doc/basic_usage.rst
+++ b/doc/basic_usage.rst
@@ -774,12 +774,35 @@ developers need for their daily workflow: a working registry is setup
 once for the whole test run, is exposed as a class attribute,
 and the tests are insulated by rollbacking the database transaction.
 
+Another interesting base class is :class:`SharedDataTestCase
+<anyblok.tests.testcase.SharedDataTestCase>`. It uses database
+savepoints to share a common fixture among tests of the same class.
+In concrete test subclasses, any data created by the ``setUpSharedData``
+classmethod will be available to all tests, and will be rollbacked
+once all of them have run. This can save a lot of time in the test runs.
+
+.. note:: it is advisable to delete the imported base class from the
+          test module, like so::
+
+            from anyblok.tests.testcase import SharedDataTestCase
+
+            class MyTest(SharedDataTestCase):
+
+               (...)
+
+            del SharedDataTestCase
+
+          in some cases, test launchers can be confused by the
+          presence of the base class in the module namespace,
+          resulting in some double launchings.
+
 We should also mention :class:`DBTestCase
 <anyblok.tests.testcase.DBTestCase>`, which is more suited for
 code that interacts at a deeper level with
 the framework (including the framework itself). It creates and drops
 the database for each test case, and therefore makes the whole run
 terribly slow, but that's sometimes a price worth paying.
+
 
 .. warning:: One must separate the launches of BlokTestCases
              and of DBTestCases in different runs.


### PR DESCRIPTION
Work in progress for a new Tests base class, which allows to share data among tests with a 2-step savepoints system.
Not intended for immediate merge : I'd like to put it in practice with anyblok_wms_base first, even though it is unit tested.

Comments already welcome, and I'm curious about what it does to coverage.