### PR TITLE
Nose tests: display Python warnings

### DIFF
--- a/anyblok/scripts.py
+++ b/anyblok/scripts.py
@@ -13,6 +13,7 @@ from anyblok.config import Configuration, get_db_name
 from anyblok.registry import RegistryManager, return_list
 from anyblok._graphviz import ModelSchema, SQLSchema
 from nose import main
+import warnings
 import sys
 from os.path import join
 from os import walk
@@ -147,6 +148,7 @@ def anyblok_updatedb():
 def anyblok_nose():
     """Run nose unit test for the registry
     """
+    warnings.simplefilter('default')
     registry = anyblok.start('nose', useseparator=True, unittest=True)
 
     defaultTest = []

--- a/anyblok_nose/plugins.py
+++ b/anyblok_nose/plugins.py
@@ -11,6 +11,7 @@ from os.path import relpath
 from os.path import normpath
 from os import pardir
 from os import walk
+import warnings
 
 
 def isindir(path, dirpath):
@@ -77,6 +78,7 @@ class AnyBlokPlugin(Plugin):
     def configure(self, options, conf):
         super(AnyBlokPlugin, self).configure(options, conf)
         if self.enabled:
+            warnings.simplefilter('default')
             self.AnyBlokOptions = Arg2OptOptions(options)
 
     def load_registry(self):


### PR DESCRIPTION
Most importantly, DeprecationWarnings should be seen during test
runs. Quoting Python documentation (version 3.5, section 29.5.5):

  To programmatically do the same as -Wd, use:

  warnings.simplefilter('default')

  (...)

  Having certain warnings ignored by default is done to prevent a user
  from seeing warnings that are only of interest to the developer.
  (...)

  The unittest module has been also updated to use the 'default' filter
  while running tests.

Certainly they had done so in the unittest runner. I couldn't find an
option for that within Nose.