### PR TITLE
Fixed hybrid_method on the alias

### DIFF
--- a/anyblok/bloks/anyblok_core/core/sqlbase.py
+++ b/anyblok/bloks/anyblok_core/core/sqlbase.py
@@ -125,7 +125,9 @@ class SqlMixin:
 
         :rtype: SqlAlchemy aliased of the model
         """
-        return aliased(cls, *args, **kwargs)
+        alias = aliased(cls, *args, **kwargs)
+        alias.registry = alias._aliased_insp._target.registry
+        return alias
 
     @classmethod
     def get_where_clause_from_primary_keys(cls, **pks):

--- a/anyblok/model/hybrid_method.py
+++ b/anyblok/model/hybrid_method.py
@@ -60,6 +60,9 @@ class HybridMethodPlugin(ModelPluginBase):
                 if self is self_:
                     return getattr(super(new_base, self), attr)(
                         self, *args, **kwargs)
+                elif hasattr(self, '_aliased_insp'):
+                    return getattr(super(new_base, self._aliased_insp._target),
+                                   attr)(self, *args, **kwargs)
                 else:
                     return getattr(super(new_base, self), attr)(
                         *args, **kwargs)

--- a/anyblok/tests/test_hybrid_method.py
+++ b/anyblok/tests/test_hybrid_method.py
@@ -103,6 +103,27 @@ class TestHybridMethod(DBTestCase):
         registry = self.init_registry(add_in_registry)
         self.check_hybrid_method(registry.Test)
 
+    def test_hybrid_with_alias(self):
+
+        def add_in_registry():
+
+            @register(Model)
+            class Test:
+                id = Integer(primary_key=True)
+                val = Integer(nullable=False)
+
+                @hybrid_method
+                def val_is(self, val):
+                    return self.val == val
+
+        registry = self.init_registry(add_in_registry)
+        self.check_hybrid_method(registry.Test)
+        Test = registry.Test.aliased()
+        query = Test.query().filter(Test.val_is(1))
+        self.assertEqual(query.count(), 1)
+        query = Test.query().filter(Test.val_is(2))
+        self.assertEqual(query.count(), 1)
+
     def add_inherited_hybrid_method(self, withcore=False, withmixin=False,
                                     withmodel=False):
 

--- a/doc/CHANGES.rst
+++ b/doc/CHANGES.rst
@@ -13,6 +13,12 @@
 CHANGELOG
 =========
 
+1.0.0
+-----
+
+* Fixed alias. The ``Model.aliased`` method link the registry into alias. The goal is 
+  to use **hybrid_method** with alias in AnyBlok.
+
 0.20.0 (2018-09-10)
 -------------------
 

--- a/doc/MEMENTO.rst
+++ b/doc/MEMENTO.rst
@@ -1524,6 +1524,8 @@ directly in the Model::
 
     .. warning:: The first arg is already passed by AnyBlok
 
+    .. warning:: Only this method give the registry into the alias, don't import **sqlalchemy.orm.aliased**
+
 Get the registry
 ~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Now Model.aliased method add the registry into alias. This action allow to use
hybrid_method or other action which need registry