### PR TITLE
Improved NoresultFound except on query.one/dictone

### DIFF
--- a/anyblok/bloks/anyblok_core/core/sqlbase.py
+++ b/anyblok/bloks/anyblok_core/core/sqlbase.py
@@ -106,9 +106,12 @@ class SqlMixin:
                 res.append(f)
 
         if res:
-            return cls.registry.query(*res)
+            query = cls.registry.query(*res)
+        else:
+            query = cls.registry.query(cls)
 
-        return cls.registry.query(cls)
+        query.set_Model(cls)
+        return query
 
     is_sql = True
 

--- a/anyblok/tests/test_core_sqlbase.py
+++ b/anyblok/tests/test_core_sqlbase.py
@@ -11,6 +11,7 @@ from anyblok.column import Integer, String, Selection
 from anyblok.relationship import Many2One, One2One, Many2Many, One2Many
 from anyblok.declarations import Declarations
 from anyblok.bloks.anyblok_core.exceptions import SqlBaseException
+from sqlalchemy.orm.exc import NoResultFound
 
 
 Model = Declarations.Model
@@ -32,6 +33,24 @@ class TestCoreSQLBase(DBTestCase):
         registry = self.init_registry(self.declare_model)
         t1 = registry.Test.insert(id2=1)
         self.assertEqual(registry.Test.query().first(), t1)
+
+    def test_query_one_is_more_explicite(self):
+        registry = self.init_registry(self.declare_model)
+        with self.assertRaises(NoResultFound) as exc:
+            registry.Test.query().one()
+
+        self.assertEqual(
+            str(exc.exception),
+            "On Model 'Model.Test': No row was found for one()")
+
+    def test_query_dictone_is_more_explicite(self):
+        registry = self.init_registry(self.declare_model)
+        with self.assertRaises(NoResultFound) as exc:
+            registry.Test.query().dictone()
+
+        self.assertEqual(
+            str(exc.exception),
+            "On Model 'Model.Test': No row was found for dictone()")
 
     def test_multi_insert(self):
         registry = self.init_registry(self.declare_model)

--- a/doc/CHANGES.rst
+++ b/doc/CHANGES.rst
@@ -21,6 +21,8 @@ CHANGELOG
   decorator with alias in AnyBlok.
 * Fixed #60: Now DateTime plugins verify also the DateTime columns of the dependencies of the Model
 * Removed **Python 3.3** compatibility
+* Improved the NoResultFound Exception for query.one and query.dictone. Now the registry name of the model
+  isadded in the exception's message
 
 0.20.0 (2018-09-10)
 -------------------


### PR DESCRIPTION
Now fr the query comes from Model.query, the NoResultFound Exception on
query.one and query.dictone add the registry name of the Model. And do a
logging.debug with the Model and the query