### PR TITLE
Fixed Column.Country

### DIFF
--- a/anyblok/column.py
+++ b/anyblok/column.py
@@ -1092,8 +1092,10 @@ class Country(Column):
     def setter_format_value(self, value):
         if value and not isinstance(value, self.sqlalchemy_type.python_type):
             value = pycountry.countries.get(
-                **{self.mode: value},
-                default=pycountry.countries.lookup(value))
+                **{
+                    self.mode: value,
+                    'default': pycountry.countries.lookup(value)
+                })
 
         return value
 

--- a/anyblok/column.py
+++ b/anyblok/column.py
@@ -1091,10 +1091,9 @@ class Country(Column):
 
     def setter_format_value(self, value):
         if value and not isinstance(value, self.sqlalchemy_type.python_type):
-            try:
-                value = pycountry.countries.get(**{self.mode: value})
-            except LookupError:
-                value = pycountry.countries.lookup(value)
+            value = pycountry.countries.get(
+                **{self.mode: value},
+                default=pycountry.countries.lookup(value))
 
         return value
 

--- a/doc/CHANGES.rst
+++ b/doc/CHANGES.rst
@@ -20,7 +20,7 @@ CHANGELOG
 * Fixed alias. The ``Model.aliased`` method link the registry into alias. The goal is 
   to use **hybrid_method** with alias in AnyBlok.
 * Fixed Column.Country, The latest version of pycountry does not raise a lookup exception
-  When the countries does not exist. Now AnyBlok adapt this change to raises the exception
+  When the countries does not exist. Now AnyBlok takes this change into consideration to raise the exception
   and keep the main behaviour
 * Fixed alias. Now the ``Model.aliased`` method links the registry instance into the aliased model.
   The goal is to use `hybrid_method <https://docs.sqlalchemy.org/en/latest/orm/extensions/hybrid.html#sqlalchemy.ext.hybrid.hybrid_method>`_ 

--- a/doc/CHANGES.rst
+++ b/doc/CHANGES.rst
@@ -17,7 +17,7 @@ CHANGELOG
 -----
 
 
-* Fixed alias. The ``Model.aliased`` method link the registry into alias. The goal is 
+* Fixed alias. The ``Model.aliased`` method now binds the registry to the alias. The goal is 
   to use **hybrid_method** with alias in AnyBlok.
 * Fixed Column.Country, The latest version of pycountry does not raise a lookup exception
   When the countries does not exist. Now AnyBlok takes this change into consideration to raise the exception

--- a/doc/CHANGES.rst
+++ b/doc/CHANGES.rst
@@ -18,6 +18,9 @@ CHANGELOG
 
 * Fixed alias. The ``Model.aliased`` method link the registry into alias. The goal is 
   to use **hybrid_method** with alias in AnyBlok.
+* Fixed Column.Country, The latest version of pycountry does not raise a lookup exception
+  When the countries does not exist. Now AnyBlok adapt this change to raises the exception
+  and keep the main behaviour
 
 0.20.0 (2018-09-10)
 -------------------


### PR DESCRIPTION
The latest version of pycountry does not raise a lookup exception. When
the countries does not exist. Now AnyBlok adapt this change to raises
the exception and keep the main behaviour