### PR TITLE
Splitted apply_model_schema_on_table method

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,7 @@ install:
   - pip install -U pip
   - pip install wheel
   - if [[ $TRAVIS_PYTHON_VERSION == 'pypy3.5' ]]; then pip install psycopg2cffi; else pip install psycopg2-binary; fi
+  - if [[ $SQLPYCLIENT == 'pymssql' ]]; then pip install 'pymssql<3.0';
   - pip install sqlalchemy mysqlclient
   - pip install -U flake8 coverage pytest pytest-cov
   - pip install colour passlib furl phonenumbers pycountry  # special columns

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ env:
           ANYBLOK_DATABASE_USER=sa \
           ANYBLOK_DATABASE_PASSWORD=AnyBl@k2019 \
           SQLSERVER='docker exec mssql /opt/mssql-tools/bin/sqlcmd -U sa -P AnyBl@k2019 -Q' \
-          SQLPYCLIENT='pymssql' \
+          SQLPYCLIENT='pymssql<3.0' \
           MARKERS='field or column or relationship'
         - |-
           ANYBLOK_DATABASE_HOST=localhost \
@@ -34,7 +34,7 @@ env:
           ANYBLOK_DATABASE_USER=sa \
           ANYBLOK_DATABASE_PASSWORD=AnyBl@k2019 \
           SQLSERVER='docker exec mssql /opt/mssql-tools/bin/sqlcmd -U sa -P AnyBl@k2019 -Q' \
-          SQLPYCLIENT='pymssql' \
+          SQLPYCLIENT='pymssql<3.0' \
           MARKERS='not field and not column and not relationship'
 
 matrix:
@@ -69,8 +69,6 @@ install:
   - pip install -U pip
   - pip install git+https://github.com/jssuzanne/sqlalchemy-utils.git@mssql_and_pymssql#egg=sqlalchemy_utils
   - pip install wheel
-  - if [[ $TRAVIS_PYTHON_VERSION == 'pypy3.5' ]]; then pip install psycopg2cffi; else pip install psycopg2-binary; fi
-  - if [[ $SQLPYCLIENT == 'pymssql' ]]; then pip install 'pymssql<3.0'; fi
   - pip install sqlalchemy $SQLPYCLIENT
   - pip install -U flake8 coverage pytest pytest-cov
   - pip install colour passlib furl phonenumbers pycountry  # special columns

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ install:
   - pip install -U pip
   - pip install wheel
   - if [[ $TRAVIS_PYTHON_VERSION == 'pypy3.5' ]]; then pip install psycopg2cffi; else pip install psycopg2-binary; fi
-  - if [[ $SQLPYCLIENT == 'pymssql' ]]; then pip install 'pymssql<3.0';
+  - if [[ $SQLPYCLIENT == 'pymssql' ]]; then pip install 'pymssql<3.0'; fi
   - pip install sqlalchemy $SQLPYCLIENT
   - pip install -U flake8 coverage pytest pytest-cov
   - pip install colour passlib furl phonenumbers pycountry  # special columns

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ install:
   - pip install wheel
   - if [[ $TRAVIS_PYTHON_VERSION == 'pypy3.5' ]]; then pip install psycopg2cffi; else pip install psycopg2-binary; fi
   - if [[ $SQLPYCLIENT == 'pymssql' ]]; then pip install 'pymssql<3.0';
-  - pip install sqlalchemy mysqlclient
+  - pip install sqlalchemy $SQLPYCLIENT
   - pip install -U flake8 coverage pytest pytest-cov
   - pip install colour passlib furl phonenumbers pycountry  # special columns
   - pip install coveralls

--- a/anyblok/mapper.py
+++ b/anyblok/mapper.py
@@ -14,7 +14,7 @@ from .config import Configuration
 def get_for(basekey, path, default=None):
     key = '%s.%s' % (basekey, '.'.join(path))
     key = key.lower()
-    
+
     if path in (['Model', '*'], ['Mixin', '*']):
         return Configuration.get(key, default)
 

--- a/anyblok/registry.py
+++ b/anyblok/registry.py
@@ -952,8 +952,9 @@ class Registry:
             self.assemble_entries()
             self.create_session_factory()
 
-            mustreload = self.apply_model_schema_on_table(
-                blok2install) or mustreload
+            self.apply_model_schema_on_table(blok2install)
+            self.listen_sqlalchemy_known_event()
+            mustreload = self.is_reload_needed() or mustreload
 
         except Exception as e:
             self.close()
@@ -1043,7 +1044,13 @@ class Registry:
         else:
             self.migration.auto_upgrade_database()
 
-        self.listen_sqlalchemy_known_event()
+    def is_reload_needed(self):
+
+        """Determines whether a reload is needed or not."""
+
+        if self.loadwithoutmigration:
+            return
+
         mustreload = False
         for entry in RegistryManager.declared_entries:
             if entry in RegistryManager.callback_initialize_entries:

--- a/doc/CHANGES.rst
+++ b/doc/CHANGES.rst
@@ -15,6 +15,13 @@
 CHANGELOG
 =========
 
+1.0.1 (Unreleased)
+------------------
+
+* Bug Fix on registry loading sequence. The **apply_model_schema_on_table**
+  method called at registry initialisation has been splitted to make sqlalchemy
+  ORM events registration independent from migration.
+
 1.0.0
 -----
 


### PR DESCRIPTION
Splitted apply_model_schema_on_table method into three more consistent parts regarding the different steps of migrating, loading slqlachemy events and reloading.

Originally, the apply_model_schema_on_table gathered either migrations, sqlalchemy ORm events registration and reload check. The execution of the whole method was conditionned by the registry.loadwithoutmigration attribute although sqlalchemy events registration whould not depend on whether system should perform a migration or not but must instead be executed at any time.

This PR is intented at proposing a better separation between migration and sqlalchemy orm events registration.