### PR TITLE
WIP: quick fix to avoid duplicate field

### DIFF
--- a/anyblok/bloks/anyblok_core/core/sqlbase.py
+++ b/anyblok/bloks/anyblok_core/core/sqlbase.py
@@ -206,7 +206,7 @@ class SqlMixin:
         query = C.query()
         query = query.filter(C.model.in_(cls.get_all_registry_names()))
         query = query.filter(C.primary_key == true())
-        return query.all().name
+        return list(set(query.all().name))
 
     @classmethod_cache()
     def _fields_description(cls):


### PR DESCRIPTION
this issue happen while coding https://github.com/AnyBlok/anyblok_furetui/pull/9/files 

```python
=============================================== FAILURES ================================================
______________________________________ TestUpdate.test_update_o2m _______________________________________

self = <anyblok_furetui.furetui.tests.test_crud.TestUpdate object at 0x7fb7239f6908>
webserver = <webtest.app.TestApp object at 0x7fb7235ec208>
rollback_registry = <anyblok.registry.Registry object at 0x7fb724735a58>
resource_tag1 = <Model.FuretUI.Resource.Tags(id=15, key='key1-update_o2m_updated', label='Tag 1', list=<Model.FuretUI.Resource.List(id=13)>, list_id=13, thumbnail=<not loaded>, thumbnail_id=None)>
resource_tag2 = <Model.FuretUI.Resource.Tags(id=16, key='tag-2', label='Tag 2', list=<Model.FuretUI.Resource.List(id=13)>, list_id=13, thumbnail=None, thumbnail_id=None)>

    def test_update_o2m(
        self, webserver, rollback_registry, resource_tag1, resource_tag2
    ):
        tag_key_update_1 = "key1-update_o2m_updated"
        tag_key1 = "key1-update_o2m_added"
        tag_key2 = "key2-update_o2m_added"
        assert len(resource_tag1.list.tags) == 2
        rollback_registry.FuretUI.CRUD.update(
            "Model.FuretUI.Resource.List",
            {"id": resource_tag1.list.id},
            {
                "Model.FuretUI.Resource.Tags": {
                    "new": {
                        "fake_uuid_tag1": {
                            "key": tag_key1,
                            "label": "Key created in o2m",
                        },
                        "fake_uuid_tag2": {
                            "key": tag_key2,
                            "label": "Key created in o2m",
                        },
                    },
                    '[["id",{}]]'.format(resource_tag1.id): {
                        "key": tag_key_update_1,
                    },
                },
                "Model.FuretUI.Resource.List": {
                    '[["id",{}]]'.format(resource_tag1.list.id): {
                        "tags": [
                            {"__x2m_state": "ADDED", "uuid": "fake_uuid_tag1"},
                            {"__x2m_state": "ADDED", "uuid": "fake_uuid_tag2"},
                            {"__x2m_state": "UPDATED", "id": resource_tag1.id},
>                           {"__x2m_state": "DELETED", "id": resource_tag2.id},
                        ],
                    }
                },
            },
        )

anyblok_furetui/furetui/tests/test_crud.py:334: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
anyblok_furetui/furetui/crud.py:277: in update
    return cls.create_or_update(model, pks, changes)
anyblok_furetui/furetui/crud.py:272: in create_or_update
    linked_model.from_primary_keys(**primary_key).furetui_delete()
anyblok_furetui/furetui/core.py:62: in furetui_delete
    return self.delete()
../../../../.pyenv/versions/3.7.3/envs/af/lib/python3.7/site-packages/anyblok/bloks/anyblok_core/core/sqlbase.py:593: in delete
    self.expire_relationship_mapped(mappers)
../../../../.pyenv/versions/3.7.3/envs/af/lib/python3.7/site-packages/anyblok/bloks/anyblok_core/core/sqlbase.py:547: in expire_relationship_mapped
    field.expire(*rfields)
../../../../.pyenv/versions/3.7.3/envs/af/lib/python3.7/site-packages/anyblok/bloks/anyblok_core/core/sqlbase.py:568: in expire
    self.registry.expire(self, fields)
../../../../.pyenv/versions/3.7.3/envs/af/lib/python3.7/site-packages/anyblok/registry.py:1075: in expire
    obj.__class__.get_hybrid_property_columns()
../../../../.pyenv/versions/3.7.3/envs/af/lib/python3.7/site-packages/anyblok/common.py:172: in wrapper
    return method(*args, **kwargs)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

cls = <class 'anyblok.model.factory.ModelFuretUIResourceList'>

    @classmethod_cache()
    def get_hybrid_property_columns(cls):
        """Return the hybrid properties columns name from the Model and the
        inherited model if they come from polymorphisme
        """
        hybrid_property_columns = cls.hybrid_property_columns
        if 'polymorphic_identity' in cls.__mapper_args__:
            pks = cls.get_primary_keys()
>           fd = cls.fields_description(*pks)
E           TypeError: fields_description() takes from 1 to 2 positional arguments but 3 were given

../../../../.pyenv/versions/3.7.3/envs/af/lib/python3.7/site-packages/anyblok/bloks/anyblok_core/core/sqlbase.py:247: TypeError
```