### PR TITLE
Add entry to load demo data while creating / updating bloks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -87,7 +87,7 @@ script:
   - if [[ $TRAVIS_PYTHON_VERSION != 'pypy3.5' ]] && [[ $MARKERS == '' ]]; then pytest --cov-report= --cov=anyblok anyblok/tests; fi
   - if [[ $TRAVIS_PYTHON_VERSION != 'pypy3.5' ]] && [[ $MARKERS != '' ]]; then pytest -m "$MARKERS" --cov-report= --cov=anyblok anyblok/tests; fi
   - $SQLSERVER 'drop database travis_ci_test;'
-  - anyblok_createdb --install-all-bloks
+  - anyblok_createdb --install-all-bloks  --with-demo
   - pytest --cov-report= --cov=anyblok anyblok/bloks
   
 after_success:

--- a/README.rst
+++ b/README.rst
@@ -96,7 +96,7 @@ To run framework tests with ``pytest``::
 
 To run tests of all installed bloks with demo data::
 
-    anyblok_createdb --with-demo --db-name test_anyblok --db-driver-name postgresql --install-all-bloks
+    anyblok_createdb --db-name test_anyblok --db-driver-name postgresql --install-all-bloks
     ANYBLOK_DATABASE_DRIVER=postgresql ANYBLOK_DATABASE_NAME=test_anyblok py.test anyblok/bloks
 
 AnyBlok is tested continuously using `Travis CI

--- a/README.rst
+++ b/README.rst
@@ -96,7 +96,7 @@ To run framework tests with ``pytest``::
 
 To run tests of all installed bloks with demo data::
 
-    anyblok_createdb --db-name test_anyblok --db-driver-name postgresql --install-all-bloks
+    anyblok_createdb --db-name test_anyblok --db-driver-name postgresql --install-all-bloks --with-demo
     ANYBLOK_DATABASE_DRIVER=postgresql ANYBLOK_DATABASE_NAME=test_anyblok py.test anyblok/bloks
 
 AnyBlok is tested continuously using `Travis CI

--- a/README.rst
+++ b/README.rst
@@ -94,9 +94,9 @@ To run framework tests with ``pytest``::
     pip install pytest
     ANYBLOK_DATABASE_DRIVER=postgresql ANYBLOK_DATABASE_NAME=test_anyblok py.test anyblok/tests
 
-To run tests of all installed bloks::
+To run tests of all installed bloks with demo data::
 
-    anyblok_createdb --db-name test_anyblok --db-driver-name postgresql --install-all-bloks
+    anyblok_createdb --with-demo --db-name test_anyblok --db-driver-name postgresql --install-all-bloks
     ANYBLOK_DATABASE_DRIVER=postgresql ANYBLOK_DATABASE_NAME=test_anyblok py.test anyblok/bloks
 
 AnyBlok is tested continuously using `Travis CI

--- a/anyblok/blok.py
+++ b/anyblok/blok.py
@@ -305,6 +305,19 @@ class Blok:
                                been installed, latest_version is None
         """
 
+    def update_demo(self, latest_version):
+        """Called on install or update to set or update demo data if
+        `System.Parameter.get("with-demo", False) is True`
+
+        :param latest_version: latest version installed, if the blok has never
+                               been installed, latest_version is None
+        """
+
+    def uninstall_demo(self):
+        """Called on uninstall demo data if
+        `System.Parameter.get("with-demo", False) is True`
+        """
+
     def uninstall(self):
         """Called on uninstall
         """

--- a/anyblok/bloks/anyblok_core/system/blok.py
+++ b/anyblok/bloks/anyblok_core/system/blok.py
@@ -218,6 +218,8 @@ class Blok:
         self.fire('Update installed blok')
         entry = self.registry.loaded_bloks[self.name]
         entry.update(None)
+        if self.registry.System.Parameter.get("with-demo", False):
+            entry.update_demo(None)
         self.state = 'installed'
         self.installed_version = self.version
 
@@ -232,6 +234,8 @@ class Blok:
             if self.installed_version is not None
             else None)
         entry.update(parsed_version)
+        if self.registry.System.Parameter.get("with-demo", False):
+            entry.update_demo(parsed_version)
         self.state = 'installed'
         self.installed_version = self.version
 
@@ -241,6 +245,8 @@ class Blok:
         logger.info("Uninstall the blok %r" % self.name)
         self.fire('Update installed blok')
         entry = BlokManager.bloks[self.name](self.registry)
+        if self.registry.System.Parameter.get("with-demo", False):
+            entry.uninstall_demo()
         entry.uninstall()
         self.state = 'uninstalled'
         self.installed_version = None

--- a/anyblok/bloks/anyblok_core/system/parameter.py
+++ b/anyblok/bloks/anyblok_core/system/parameter.py
@@ -13,6 +13,8 @@ from ..exceptions import ParameterException
 register = Declarations.register
 System = Declarations.Model.System
 
+NOT_PROVIDED = object
+
 
 @register(Declarations.Model.System)
 class Parameter:
@@ -64,17 +66,21 @@ class Parameter:
         return True if query.count() else False
 
     @classmethod
-    def get(cls, key):
+    def get(cls, key, default=NOT_PROVIDED):
         """ Return the value of the key
 
         :param key: key whose value to retrieve
+        :param default: default value if key does not exists
         :return: associated value
         :rtype: anything JSON encodable
-        :raises ParameterException: if the key doesn't exist.
+        :raises ParameterException: if the key doesn't exist and default is not
+                                    set.
         """
         if not cls.is_exist(key):
-            raise ParameterException(
-                "unexisting key %r" % key)
+            if default is NOT_PROVIDED:
+                raise ParameterException(
+                    "unexisting key %r" % key)
+            return default
 
         param = cls.from_primary_keys(key=key)
         if param.multi:

--- a/anyblok/bloks/anyblok_core/tests/test_core_base.py
+++ b/anyblok/bloks/anyblok_core/tests/test_core_base.py
@@ -13,6 +13,7 @@ from ..exceptions import CoreBaseException
 
 @pytest.mark.usefixtures('rollback_registry')
 class TestCoreBaseScope:
+
     def test_to_primary_keys(self, rollback_registry):
         registry = rollback_registry
         with pytest.raises(CoreBaseException):

--- a/anyblok/bloks/anyblok_core/tests/test_system_params.py
+++ b/anyblok/bloks/anyblok_core/tests/test_system_params.py
@@ -58,8 +58,14 @@ class TestSystemParameter:
     def test_get_with_default(self, rollback_registry):
         registry = rollback_registry
         Parameter = registry.System.Parameter
-        assert Parameter.get('test.parameter', default="default value") == "default value"
-        assert Parameter.get('test.parameter', "default value") == "default value"
+        assert (
+            Parameter.get('test.parameter', default="default value") ==
+            "default value"
+        )
+        assert (
+            Parameter.get('test.parameter', "default value") ==
+            "default value"
+        )
         assert Parameter.get('test.parameter', None) is None
         assert Parameter.get('test.parameter', True) is True
         assert Parameter.get('test.parameter', False) is False

--- a/anyblok/bloks/anyblok_core/tests/test_system_params.py
+++ b/anyblok/bloks/anyblok_core/tests/test_system_params.py
@@ -55,6 +55,15 @@ class TestSystemParameter:
         with pytest.raises(ParameterException):
             Parameter.get('test.parameter')
 
+    def test_get_with_default(self, rollback_registry):
+        registry = rollback_registry
+        Parameter = registry.System.Parameter
+        assert Parameter.get('test.parameter', default="default value") == "default value"
+        assert Parameter.get('test.parameter', "default value") == "default value"
+        assert Parameter.get('test.parameter', None) is None
+        assert Parameter.get('test.parameter', True) is True
+        assert Parameter.get('test.parameter', False) is False
+
     def test_count(self, rollback_registry):
         registry = rollback_registry
         Parameter = registry.System.Parameter

--- a/anyblok/bloks/anyblok_core/tests/test_testing.py
+++ b/anyblok/bloks/anyblok_core/tests/test_testing.py
@@ -2,11 +2,24 @@ import pytest
 
 
 @pytest.mark.skip_unless_demo_data_installed
-def test_skip_rollback_registry(rollback_registry):
-    # Anyblok test case database is setup without --with-demo so this
-    # test should be skipped in order to validate and honor
+def test_skip_without_demo_rollback_registry(rollback_registry):
+    # If Anyblok test case database is setup without `--with-demo` so this
+    # test should be skipped otherwise `with-demo` parameter should be True
+    assert rollback_registry.System.Parameter.get("with-demo", False) is True, (
+        "`--with-demo` is not used to setup database to run AnyBlok tests "
+        "so this test is intentionally skipped to validate "
+        "skip_unless_demo_data_installed pytest marker behavior"
+    )
+
+
+@pytest.mark.skip_while_demo_data_installed
+def test_skip_with_demo_rollback_registry(rollback_registry):
+    # If Anyblok test case database is setup with `--with-demo` so this
+    # test should be skipped otherwise `with-demo` parameter should be False
     # skip_unless_demo_data_installed marker
-    raise Exception(
+    assert rollback_registry.System.Parameter.get(
+        "with-demo", False
+    ) is False, (
         "`--with-demo` is not used to setup database to run AnyBlok tests "
         "so this test is intentionally skipped to validate "
         "skip_unless_demo_data_installed pytest marker behavior"

--- a/anyblok/bloks/anyblok_core/tests/test_testing.py
+++ b/anyblok/bloks/anyblok_core/tests/test_testing.py
@@ -1,0 +1,13 @@
+import pytest
+
+
+@pytest.mark.skip_unless_demo_data_installed
+def test_skip_rollback_registry(rollback_registry):
+    # Anyblok test case database is setup without --with-demo so this
+    # test should be skipped in order to validate and honor
+    # skip_unless_demo_data_installed marker
+    raise Exception(
+        "`--with-demo` is not used to setup database to run AnyBlok tests "
+        "so this test is intentionally skipped to validate "
+        "skip_unless_demo_data_installed pytest marker behavior"
+    )

--- a/anyblok/config.py
+++ b/anyblok/config.py
@@ -865,6 +865,16 @@ def add_create_database(group):
         '--db-template-name',
         default=os.environ.get('ANYBLOK_DATABASE_TEMPLATE_NAME'),
         help="Name of the template")
+    group.add_argument(
+        '--with-demo',
+        default=os.environ.get('ANYBLOK_WITH_DEMO', False),
+        action='store_true',
+        help="Call **update_demo** method define on bloks to import demo data "
+             "while installing the project. If this option is used at database "
+             "creation that information will be kept in the database then "
+             "**update_demo** method will be called while updating bloks as "
+             "well.",
+    )
 
 
 @Configuration.add('install-bloks')

--- a/anyblok/conftest.py
+++ b/anyblok/conftest.py
@@ -53,7 +53,24 @@ def init_session(request, configuration_loaded):
 
 @pytest.fixture(scope='function')
 def rollback_registry(request, init_session):
+    """Provide registry that is rollback between each tests
+
+    If you want to skip test if demo data are not installed you can
+    place ``skip_unless_demo_data_installed`` pytest marker::
+
+    @pytest.mark.skip_unless_demo_data_installed
+    def test_somthing(rollback_registry):
+        registry = rollback_registry
+        ...
+    """
     registry = init_session
+
+    if request.node.get_closest_marker('skip_unless_demo_data_installed'):
+        if not registry.System.Parameter.get("with-demo", False):
+            pytest.skip(
+                "Demo data are required (Use ``--with-demo`` to create the "
+                "test database)."
+            )
 
     yield registry
 

--- a/anyblok/conftest.py
+++ b/anyblok/conftest.py
@@ -62,15 +62,34 @@ def rollback_registry(request, init_session):
     def test_somthing(rollback_registry):
         registry = rollback_registry
         ...
+
+    If you want to skip test if demo data are installed you can
+    place ``skip_while_demo_data_installed`` pytest marker::
+
+    @pytest.mark.skip_while_demo_data_installed
+    def test_somthing(rollback_registry):
+        registry = rollback_registry
+        ...
     """
     registry = init_session
 
-    if request.node.get_closest_marker('skip_unless_demo_data_installed'):
-        if not registry.System.Parameter.get("with-demo", False):
-            pytest.skip(
-                "Demo data are required (Use ``--with-demo`` to create the "
-                "test database)."
-            )
+    if (
+        request.node.get_closest_marker('skip_unless_demo_data_installed') and
+        not registry.System.Parameter.get("with-demo", False)
+    ):
+        pytest.skip(
+            "Demo data are required (Use ``--with-demo`` to create the "
+            "test database)."
+        )
+
+    if (
+        request.node.get_closest_marker('skip_while_demo_data_installed') and
+        registry.System.Parameter.get("with-demo", False)
+    ):
+        pytest.skip(
+            "Demo data are present (Do not use ``--with-demo`` to create the "
+            "test database)."
+        )
 
     yield registry
 

--- a/anyblok/scripts.py
+++ b/anyblok/scripts.py
@@ -101,6 +101,9 @@ def anyblok_createdb():
     if registry is None:
         return
 
+    registry.System.Parameter.set("with-demo", Configuration.get('with_demo', False))
+
+
     if Configuration.get('install_all_bloks'):
         bloks = registry.System.Blok.list_by_state('uninstalled')
     else:

--- a/anyblok/scripts.py
+++ b/anyblok/scripts.py
@@ -101,8 +101,8 @@ def anyblok_createdb():
     if registry is None:
         return
 
-    registry.System.Parameter.set("with-demo", Configuration.get('with_demo', False))
-
+    registry.System.Parameter.set(
+        "with-demo", Configuration.get('with_demo', False))
 
     if Configuration.get('install_all_bloks'):
         bloks = registry.System.Blok.list_by_state('uninstalled')

--- a/anyblok/test_bloks/test_blok16/README.rst
+++ b/anyblok/test_bloks/test_blok16/README.rst
@@ -1,0 +1,27 @@
+.. This file is a part of the AnyBlok project
+..
+..    Copyright (C) 2020 Pierre Verkest <pierreverkest84@gmail.com>
+..
+.. This Source Code Form is subject to the terms of the Mozilla Public License,
+.. v. 2.0. If a copy of the MPL was not distributed with this file,You can
+.. obtain one at http://mozilla.org/MPL/2.0/.
+
+Test blok16
+===========
+
+Test Blok16 is used to validate the order of calls over following methods:
+
+* pre_migration
+* post_migration
+* update
+* update_demo
+
+* uninstall
+* uninstall_demo
+
+In différent cases playing with following options:
+
+* with-demo system parameter
+* withoutautomigration
+* loadwithoutmigration
+

--- a/anyblok/test_bloks/test_blok16/__init__.py
+++ b/anyblok/test_bloks/test_blok16/__init__.py
@@ -10,7 +10,7 @@ from anyblok.blok import Blok
 
 class TestBlok(Blok):
 
-    version = '1.0.0'
+    version = "1.0.0"
 
     called_methods = []
 

--- a/anyblok/test_bloks/test_blok16/__init__.py
+++ b/anyblok/test_bloks/test_blok16/__init__.py
@@ -1,0 +1,33 @@
+# This file is a part of the AnyBlok project
+#
+#    Copyright (C) 2020 Pierre Verkest <pierreverkest84@gmail.com>
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file,You can
+# obtain one at http://mozilla.org/MPL/2.0/.
+from anyblok.blok import Blok
+
+
+class TestBlok(Blok):
+
+    version = '1.0.0'
+
+    called_methods = []
+
+    def pre_migration(self, latest_version):
+        self.__class__.called_methods.append("pre_migration")
+
+    def update(self, latest_version):
+        self.__class__.called_methods.append("update")
+
+    def post_migration(self, latest_version):
+        self.__class__.called_methods.append("post_migration")
+
+    def update_demo(self, latest_version):
+        self.__class__.called_methods.append("update_demo")
+
+    def uninstall(self):
+        self.__class__.called_methods.append("uninstall")
+
+    def uninstall_demo(self):
+        self.__class__.called_methods.append("uninstall_demo")

--- a/anyblok/testing.py
+++ b/anyblok/testing.py
@@ -117,7 +117,7 @@ class TestCase(unittest.TestCase):
         Configuration.update(**env)
 
     @classmethod
-    def createdb(cls, keep_existing=False):
+    def createdb(cls, keep_existing=False, with_demo=False):
         """Create the database specified in configuration.
 
         ::
@@ -136,6 +136,14 @@ class TestCase(unittest.TestCase):
             drop_database(url)
 
         create_database(url, template=db_template_name)
+
+        registry = RegistryManager.get(Configuration.get('db_name', None))
+        if registry is None:
+            return
+
+        registry.System.Parameter.set(
+            "with-demo", Configuration.get('with_demo', with_demo))
+
         return True
 
     @classmethod

--- a/anyblok/tests/test_blok.py
+++ b/anyblok/tests/test_blok.py
@@ -947,3 +947,15 @@ class TestBlokInstallLifeCycle:
         assert blok.called_methods == [
             "pre_migration", "post_migration", "update", "update_demo",
         ]
+
+
+@pytest.mark.skip_unless_demo_data_installed
+def test_skip_rollback_registry(rollback_registry):
+    # Anyblok test case database is setup without --with-demo so this
+    # test should be skipped in order to validate and honor
+    # skip_unless_demo_data_installed marker
+    raise Exception(
+        "`--with-demo` is not used to setup database to run AnyBlok tests "
+        "so this test is intentionally skipped to validate "
+        "skip_unless_demo_data_installed pytest marker behavior"
+    )

--- a/anyblok/tests/test_blok.py
+++ b/anyblok/tests/test_blok.py
@@ -947,15 +947,3 @@ class TestBlokInstallLifeCycle:
         assert blok.called_methods == [
             "pre_migration", "post_migration", "update", "update_demo",
         ]
-
-
-@pytest.mark.skip_unless_demo_data_installed
-def test_skip_rollback_registry(rollback_registry):
-    # Anyblok test case database is setup without --with-demo so this
-    # test should be skipped in order to validate and honor
-    # skip_unless_demo_data_installed marker
-    raise Exception(
-        "`--with-demo` is not used to setup database to run AnyBlok tests "
-        "so this test is intentionally skipped to validate "
-        "skip_unless_demo_data_installed pytest marker behavior"
-    )

--- a/anyblok/tests/test_many2one.py
+++ b/anyblok/tests/test_many2one.py
@@ -568,7 +568,7 @@ class TestMany2OneOld:
         registry = self.init_registry(add_in_registry)
         inspector = Inspector(registry.session.connection())
         pks = inspector.get_primary_keys(registry.Person.__tablename__)
-        assert 'address_id'in pks
+        assert 'address_id' in pks
 
     def test_complet_with_multi_foreign_key(self):
 

--- a/doc/CHANGES.rst
+++ b/doc/CHANGES.rst
@@ -53,6 +53,8 @@ CHANGELOG
   * mssql: pymssql
   * pyodbc
 
+* System.Parameter.get do not raise if a default value is provided
+
 0.22.5 (2019-06-24)
 -------------------
 

--- a/doc/CHANGES.rst
+++ b/doc/CHANGES.rst
@@ -54,6 +54,8 @@ CHANGELOG
   * pyodbc
 
 * System.Parameter.get do not raise if a default value is provided
+* Add ``--with-demo`` parameter while creating a database (anyblok_createdb) in
+  order to load demo data while installing bloks on that database.
 
 0.22.5 (2019-06-24)
 -------------------

--- a/doc/MEMENTO.rst
+++ b/doc/MEMENTO.rst
@@ -91,6 +91,22 @@ And the methods that define blok behaviours:
 |                               | ``latest_verison`` is an                    |
 |                               | **pkg_resources.parse_version**             |
 +-------------------------------+---------------------------------------------+
+| ``update_demo``               | Action to do when the blok is being         |
+|                               | install or updated. Called after ``update`` |
+|                               | if database was created with ``--with-demo``|
+|                               | parameter.                                  |
+|                               | This method has one argument                |
+|                               | ``latest_version`` (None for install)       |
+|                               |                                             |
+|                               | Since version **0.20.0** the                |
+|                               | ``latest_verison`` is an                    |
+|                               | **pkg_resources.parse_version**             |
++-------------------------------+---------------------------------------------+
+| ``uninstall_demo``            | Action to do when the blok is being         |
+|                               | uninstalled. Called before ``uninstall``    |
+|                               | if database was created with ``--with-demo``|
+|                               | parameter.                                  |
++-------------------------------+---------------------------------------------+
 | ``uninstall``                 | Action to do when the blok is being         |
 |                               | uninstalled                                 |
 +-------------------------------+---------------------------------------------+

--- a/doc/basic_usage.rst
+++ b/doc/basic_usage.rst
@@ -80,14 +80,41 @@ File tree::
         logo = 'relative/path'
 
         def install(self):
-            """ method called at blok installation time """
+            """This room will be always present after the blok installation
+            """
+            address = self.registry.Address.insert(
+                street='la Tour Eiffel',
+                street2='5 avenue Anatole France',
+                zip='75007',
+                city='Paris'
+            )
+            self.registry.Room.insert(number=1, address=address)
+
+        def install_demo(self):
+            """Extra data to add once blok is installed if database was created
+            with ``--with-demo``.
+            """
             address = self.registry.Address.insert(street='14-16 rue Soleillet',
                                                    zip='75020', city='Paris')
             self.registry.Room.insert(number=308, address=address)
 
         def update(self, latest_version):
+            """Method called when blok is installed or updated to let
+            a chance to add data or configuration.
+            """
             if latest_version is None:
                 self.install()
+
+        def update_demo(self, latest_version):
+            """Method called when blok is installed or updated if database
+            was created with the `--with-demo` parameter in order to add demo
+            data to quickly present product with examples or to
+            populate database with data that could be use in test case.
+
+            This method is called after ``update``.
+            """
+            if latest_version is None:
+                self.install_demo()
 
         @classmethod
         def import_declaration_module(cls):
@@ -121,14 +148,14 @@ File tree::
 
         version = '1.0.0'
 
-        def install(self):
+        def install_demo(self):
             self.registry.Position.multi_insert({'name': 'CTO'},
                                                 {'name': 'CEO'},
                                                 {'name': 'Administrative Manager'},
                                                 {'name': 'Project Manager'},
                                                 {'name': 'Developer'})
 
-        def update(self, latest_version):
+        def update_demo(self, latest_version):
             if latest_version is None:
                 self.install()
 
@@ -186,7 +213,7 @@ File tree::
                                           "Jean-Sébastien Suzanne")]
             self.registry.Employee.multi_insert(*employees)
 
-        def update(self, latest_version):
+        def update_demo(self, latest_version):
             if latest_version is None:
                 self.install()
 
@@ -240,7 +267,7 @@ File tree::
                 Employee.query().filter(Employee.name == employee).update({
                     'position_name': position})
 
-        def update(self, latest_version):
+        def update_demo(self, latest_version):
             if latest_version is None:
                 self.install()
 

--- a/setup.py
+++ b/setup.py
@@ -120,6 +120,7 @@ setup(
             'test-blok13=anyblok.test_bloks.test_blok13:TestBlok',
             'test-blok14=anyblok.test_bloks.test_blok14:TestBlok',
             'test-blok15=anyblok.test_bloks.test_blok15:TestBlok',
+            'test-blok16=anyblok.test_bloks.test_blok16:TestBlok',
         ],
         'nose.plugins.0.10': [
             'anyblok-bloks=anyblok_nose.plugins:AnyBlokPlugin',


### PR DESCRIPTION
- [x] System.paramter.get with default value if not exits
- [x] add `--with-demo` parameter in command line to load demo data
- [x] add `update_demo` and `uninstall_demo` on blok object
- [x] call `update_demo` and test it
- [x] call `uninstall_demo` and test it
- [x] add facilities for unitit tests while creating db (with or without demo)
- [x] add facilities to declare test that is running only against a database with demo data
- [x] document somehow