### PR TITLE
Password column, allow to set password usin hash password directly

### DIFF
--- a/anyblok/column.py
+++ b/anyblok/column.py
@@ -846,7 +846,7 @@ class Password(Column):
         @Declarations.register(Declarations.Model)
         class Test:
 
-            x = Password(crypt_context={'schemes': ['md5_crypt']})
+            x = Password(crypt_context={'schemes': ['bcrypt']})
 
         =========================================
 
@@ -855,6 +855,8 @@ class Password(Column):
 
         test.x
         ==> Password object with encrypt value, the value can not be read
+
+        test.x = "$2y$10$KlpJgedTiIH7SSBFOdooJuS4Gnoqv9qEUwDfqkxZ7iB2DRhg758li"
 
         test.x == 'mypassword'
         ==> True
@@ -887,7 +889,9 @@ class Password(Column):
         :param value:
         :return:
         """
-        value = self.sqlalchemy_type.context.hash(value).encode("utf8")
+        if not self.sqlalchemy_type.context.identify(value):
+            value = self.sqlalchemy_type.context.hash(value).encode("utf8")
+
         value = SAU_PWD(value, context=self.sqlalchemy_type.context)
         return value
 

--- a/anyblok/tests/test_column.py
+++ b/anyblok/tests/test_column.py
@@ -533,6 +533,23 @@ class TestColumns:
         )
 
     @pytest.mark.skipif(not has_passlib, reason="passlib is not installed")
+    def test_password_set_with_hash(self):
+        registry = self.init_registry(
+            simple_column,
+            ColumnType=Password,
+            crypt_context={"schemes": ["bcrypt"]},
+        )
+        bcrypt_password_hash = (
+            "$2y$10$Crnf9zkl67BugBmA4ASoU.phSGda4ir4JzaU64jpg2h.s92dSsaUu"
+        )
+        test = registry.Test.insert(col=bcrypt_password_hash)
+        assert test.col == "password"
+        assert (
+            registry.execute(text("Select col from test")).fetchone()[0]
+            != bcrypt_password_hash
+        )
+
+    @pytest.mark.skipif(not has_passlib, reason="passlib is not installed")
     def test_password_with_foreign_key(self):
         with pytest.raises(FieldException):
             self.init_registry(

--- a/anyblok/tests/test_column.py
+++ b/anyblok/tests/test_column.py
@@ -544,10 +544,6 @@ class TestColumns:
         )
         test = registry.Test.insert(col=bcrypt_password_hash)
         assert test.col == "password"
-        assert (
-            registry.execute(text("Select col from test")).fetchone()[0]
-            != bcrypt_password_hash
-        )
 
     @pytest.mark.skipif(not has_passlib, reason="passlib is not installed")
     def test_password_with_foreign_key(self):

--- a/doc/CHANGES.rst
+++ b/doc/CHANGES.rst
@@ -18,6 +18,11 @@
 
 CHANGELOG
 =========
+2.3.0 (UNRELEASED)
+------------------
+
+* Password column can be set using hash (only scheme using defined in field
+  definition).
 
 2.2.0 (2024-02-18)
 ------------------


### PR DESCRIPTION
This can be usefull while migrating existing data or setup data using hash password commited in setup data.